### PR TITLE
Fix region-aware EKS cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,20 @@
 /Gemfile.lock
 /favicon.ico
 _site/
+
+# Deployment runtime files
+eks/deployment_output.txt
+eks/ec2_output.json
+eks/flag.txt
+eks/checkpoint.txt
+eks/saved_variables.txt
+eks/eks-cluster-config.yaml
+eks/peachycloudsecurity-eks-policy.json
+eks/peachycloudsecurity-ekstrust-policy.json
+eks/ec2_terraform/ec2_policy.json
+eks/ec2_terraform/trust-policy.json
+
+# Terraform runtime files
+eks/ec2_terraform/.terraform/
+eks/ec2_terraform/*.tfstate
+eks/ec2_terraform/*.tfstate.*

--- a/eks/deploy.sh
+++ b/eks/deploy.sh
@@ -483,6 +483,7 @@ fi
 
 
 echo "Repo Suffix: ${REPO_SUFFIX}" > $OUTPUT_FILE
+echo "AWS Region: ${REGION}" >> $OUTPUT_FILE
 echo "ECR Repository Name: ${REPO_NAME}" >> $OUTPUT_FILE
 echo "ECR Repository URL: ${REPO_URL}" >> $OUTPUT_FILE
 echo "EKS Cluster Name: ${EKS_CLUSTER_NAME}" >> $OUTPUT_FILE

--- a/eks/destroy.sh
+++ b/eks/destroy.sh
@@ -24,6 +24,7 @@ else
   
   # Extract variables and save them to a file
   export REPO_SUFFIX=$(grep "Repo Suffix:" deployment_output.txt 2>/dev/null | awk '{print $3}' || echo "")
+  export DEPLOYED_REGION=$(grep "AWS Region:" deployment_output.txt 2>/dev/null | awk '{print $3}' || echo "")
   export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
   export CLUSTER_NAME=$(grep "EKS Cluster Name:" deployment_output.txt 2>/dev/null | awk '{print $4}' || echo "")
   export REPO_NAME=$(grep "ECR Repository Name:" deployment_output.txt 2>/dev/null | awk '{print $4}' || echo "")
@@ -38,6 +39,7 @@ else
   cat <<EOL > "$VARIABLES_FILE"
 export DEFAULT_REGION="$DEFAULT_REGION"
 export REPO_SUFFIX="$REPO_SUFFIX"
+export DEPLOYED_REGION="$DEPLOYED_REGION"
 export AWS_ACCOUNT_ID="$AWS_ACCOUNT_ID"
 export CLUSTER_NAME="$CLUSTER_NAME"
 export REPO_NAME="$REPO_NAME"
@@ -48,6 +50,11 @@ export INSTANCE_PROFILE_NAME="$INSTANCE_PROFILE_NAME"
 export S3_POLICY_NAME="$S3_POLICY_NAME"
 export CLOUDFORMATION_STACK_NAME="$CLOUDFORMATION_STACK_NAME"
 EOL
+fi
+
+# Older deployment output did not include the region, so use the EC2 ARN when available.
+if [ -z "${DEPLOYED_REGION:-}" ] && [ -f "ec2_output.json" ]; then
+  export DEPLOYED_REGION=$(jq -r '.instance_arn.value // empty | split(":")[3]' ec2_output.json 2>/dev/null || echo "")
 fi
 
 # Check if a region argument is provided, otherwise use the default region
@@ -63,6 +70,28 @@ else
     exit 1
   fi
 fi
+
+if [ -n "${DEPLOYED_REGION:-}" ] && [ "$DEPLOYED_REGION" != "$REGION" ]; then
+  echo "Error: Deployment resources are in ${DEPLOYED_REGION}, not ${REGION}."
+  exit 1
+fi
+
+eks_cluster_exists() {
+  local output
+  output=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" --query 'cluster.status' --output text 2>&1)
+  local status=$?
+
+  if [ $status -eq 0 ]; then
+    return 0
+  fi
+
+  if [[ "$output" == *"ResourceNotFoundException"* ]]; then
+    return 1
+  fi
+
+  echo "Error: Unable to check EKS cluster ${CLUSTER_NAME}: ${output}" >&2
+  return 2
+}
 
 # Loop through the checkpoints and execute the corresponding actions
 while true; do
@@ -81,18 +110,39 @@ while true; do
     "CHECKPOINT_1")
       echo "Deleting EKS cluster with name ${CLUSTER_NAME} in region ${REGION}..."
       # Check if cluster exists before trying to delete
-      if eksctl get cluster --name ${CLUSTER_NAME} --region ${REGION} &>/dev/null; then
-        eksctl delete cluster --name ${CLUSTER_NAME} --region ${REGION}
+      if eks_cluster_exists; then
+        eksctl delete cluster --name ${CLUSTER_NAME} --region ${REGION} || exit 1
+
+        if aws cloudformation describe-stacks --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION} &>/dev/null; then
+          echo "Waiting for stack deletion to complete..."
+          aws cloudformation wait stack-delete-complete --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION} || exit 1
+        fi
       else
+        cluster_status=$?
+        if [ $cluster_status -eq 2 ]; then
+          exit 1
+        fi
+
         echo "Cluster ${CLUSTER_NAME} does not exist, skipping cluster deletion."
         # If cluster doesn't exist, try to delete CloudFormation stack if it exists
         if aws cloudformation describe-stacks --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION} &>/dev/null; then
           echo "Deleting CloudFormation stack ${CLOUDFORMATION_STACK_NAME}..."
           aws cloudformation delete-stack --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION}
           echo "Waiting for stack deletion to complete..."
-          aws cloudformation wait stack-delete-complete --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION} || true
+          aws cloudformation wait stack-delete-complete --stack-name ${CLOUDFORMATION_STACK_NAME} --region ${REGION} || exit 1
         fi
       fi
+
+      if eks_cluster_exists; then
+        echo "Cluster ${CLUSTER_NAME} still exists."
+        exit 1
+      else
+        cluster_status=$?
+        if [ $cluster_status -eq 2 ]; then
+          exit 1
+        fi
+      fi
+
       echo "CHECKPOINT_2" > "$CHECKPOINT_FILE"
       ;;
 


### PR DESCRIPTION
## Description
Running `destroy.sh` without `--region` defaults to `us-west-2`. When the lab was deployed in `us-east-1`, the script checked EKS and ECR in the wrong region and still advanced the cleanup checkpoint. Retrying with the correct region then resumed after those stages, leaving the EKS cluster behind.

EKS deletion could also return before the CloudFormation stack finished deleting. In the reproduced case, the stack later entered `DELETE_FAILED` while the script had already continued.

This change records the deployment region, rejects a known region mismatch before cleanup starts, and falls back to the EC2 ARN for older deployment output. It also distinguishes a missing cluster from AWS API errors, waits for CloudFormation deletion, and verifies that the cluster is gone before advancing the checkpoint. Generated deployment and Terraform state files are ignored.

### Testing
- `bash -n eks/deploy.sh`
- `bash -n eks/destroy.sh`
- verified that the default region is rejected for a deployment recorded in another region
- verified explicit region mismatch handling
- verified the EC2 ARN fallback for older deployment output
- verified the original invalid-argument behavior remains unchanged

### Documentation
No documentation changes are required. Existing commands and user-facing messages remain unchanged.

### Checklist
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required